### PR TITLE
Add an HUD example

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,14 @@
     "version": "0.2.0",
     "configurations": [
         {
+            //"debugServer": 4711,
+            "type": "stingray",
+            "request": "attach",
+            "name": "Stingray Editor",
+            "ip": "127.0.0.1",
+            "port": 14030
+        },
+        {
             "name": "Dev Tools",
             "type": "chrome",
             "request": "attach",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,6 +27,7 @@
         "**/packages": true,
         "**/build": true,
         "**/binaries": true,
-        "**/node_modules": true
+        "**/node_modules": true,
+        "**/.stingray-asset-server-directory": true
     }
 }

--- a/engine/html5_web_app.cpp
+++ b/engine/html5_web_app.cpp
@@ -68,7 +68,7 @@ CefRefPtr<WebApp> WebApp::init()
 	settings.windowless_rendering_enabled = true;
 	settings.single_process = true;
 	settings.no_sandbox = true;
-	#ifdef _DEBUG
+	#if defined(DEVELOPMENT)
 		settings.remote_debugging_port = 9089;
 	#endif
 

--- a/plugin/html5-actions.js
+++ b/plugin/html5-actions.js
@@ -1,9 +1,0 @@
-define(require => {
-    function runApplication () {
-        console.warn('run application');
-    }
-
-    return {
-        runApplication
-    };
-});

--- a/plugin/html5-examples.js
+++ b/plugin/html5-examples.js
@@ -1,0 +1,15 @@
+define(require => {
+    "use strict";
+
+    const engineService = require('services/engine-service');
+
+    function showHud () {
+        return engineService.evaluateScript(`(require "html5_examples/html5_hud")()`)
+            .then(result => console.info(JSON.stringify(result)))
+            .catch(err => console.error('Failed to execute HTML5 example:\r\n' + err)); 
+    }
+
+    return {
+        showHud
+    };
+});

--- a/plugin/html5.stingray_plugin
+++ b/plugin/html5.stingray_plugin
@@ -22,39 +22,22 @@ extensions = {
 
     resources = [
         { path = "html5_resources" }
+        { path = "html5_examples" }
     ]
 
     actions = [
-        { name = "html5-run-application" type = "js" module = "html5-actions" function_name = "runApplication"}
+        { name = "html5-example-hud" type = "js" module = "html5-examples" function_name = "showHud"}
     ]
 
     menus = [
         { path = "HTML5" order = 15003 }
-        { path = "HTML5/Run" order = 10 action = "html5-run-application" }
+        { path = "HTML5/Example HUD" order = 10 action = "html5-example-hud" }
     ]
 
     asset_types = [
-        {
-            type = "html5"
-            category = "HTML5"
-            icon = "sample_project/thumbnail.png"
-            name = "HTML5 Project"
-            description = "HTML5 Project"
-        }
-
-        {
-            type = "html"
-            category = "HTML5"
-            icon = "sample_project/thumbnail.png"
-            name = "HTML page"
-        }
-
-        {
-            type = "js"
-            category = "HTML5"
-            icon = "sample_project/thumbnail.png"
-            name = "JavaScript"
-        }
+        { type = "html5" category = "HTML5" icon = "sample_project/thumbnail.png" name = "HTML5 Project" description = "HTML5 Project" }
+        { type = "html" category = "HTML5" icon = "sample_project/thumbnail.png" name = "HTML page" }
+        { type = "js" category = "HTML5" icon = "sample_project/thumbnail.png" name = "JavaScript" }
     ]
 
     runtime_libraries = [

--- a/plugin/html5_examples/html5_hud.lua
+++ b/plugin/html5_examples/html5_hud.lua
@@ -1,6 +1,176 @@
 
+local Window = stingray.Window;
+local Application = stingray.Application;
+local World = stingray.World;
+local WebView = stingray.WebView;
+
+local web_view_material_resource_name = "html5_resources/web_view_2d"
+
+Html5ExampleHudViewport = class(Html5ExampleHudViewport)
+
+function Html5ExampleHudViewport:init(id, editor, window)
+    self._id = id
+    self._editor = editor
+    self._window = window
+
+    self:init_world()
+    self:init_camera()
+end
+
+function Html5ExampleHudViewport:shutdown()
+
+    if self._web_view then
+        WebView.destroy(self._web_view)
+    end
+
+    World.destroy_unit(self._world, self._light)
+    Application.destroy_viewport(self._world, self._viewport)
+    World.destroy_shading_environment(self._world, self._shading_environment)
+    Application.release_world(self._world)
+
+    if Window and self._window then
+        Window.close(self._window)
+    end
+
+    self._web_view = nil
+    self._viewport = nil
+    self._window = nil
+end
+
+function Html5ExampleHudViewport:init_world()
+    -- Deactivate Cloth => cloth meshes will fall back to standard skinning rendering,
+    -- which is enough and immediate, whereas Cloth needs at least one frame to render.
+    self._world = Application.new_world(stingray.Application.DISABLE_APEX_CLOTH)
+    self._viewport = Application.create_viewport(self._world, "default")
+    self._gui = World.create_screen_gui(self._world, "immediate")
+    self._material_name = "core/editor_slave/resources/gui/thumbnail"
+    self._material = Gui.material(self._gui, self._material_name)
+    self._checkerboard = "core/editor_slave/resources/gui/checkerboard"
+    self._checkerboard_hdr = "core/editor_slave/resources/gui/checkerboard_hdr"
+    self._light = self._editor:create_preview_light(self._world)
+
+    self._shading_environment = World.create_shading_environment(self._world)
+
+    Material.set_scalar(Gui.material(self._gui, self._checkerboard), "size", 32)
+    Material.set_scalar(Gui.material(self._gui, self._checkerboard_hdr), "size", 32)
+
+    World.set_flow_enabled(self._world, false)
+    World.set_editor_flow_enabled(self._world, false)
+end
+
+function Html5ExampleHudViewport:init_camera()
+    self._editor_camera = EditorCamera.create_viewport_editor_camera(self._id, self._world, {"QuakeStyleMouseLook", "MayaStylePan"})
+    self._camera = self._editor_camera._camera
+end
+
+function Html5ExampleHudViewport:update(editor_viewport, dt)
+    if self._web_view then
+        WebView.update(self._web_view, dt)
+    end
+
+    World.update(self._world, dt)
+end
+
+function Html5ExampleHudViewport:render(editor_viewport, lines, lines_no_z)
+    if self._web_view then
+         local maxw, maxh = Gui.resolution(self._viewport, self._window)
+         --print("render wv", maxw, maxh)
+         WebView.render(self._web_view)
+         Gui.bitmap(self._gui, web_view_material_resource_name, Vector2(0, 0), Vector2(maxw, maxh))
+     end
+
+     if self._window ~= nil then
+        Application.render_world(self._world, self._editor_camera:camera(), self._viewport, self._shading_environment, self._window)
+    else
+        Application.render_world(self._world, self._editor_camera:camera(), self._viewport, self._shading_environment)
+    end
+end
+
+function Html5ExampleHudViewport:is_dirty()
+    return true
+end
+
+function Html5ExampleHudViewport:is_accepting_drag_and_drop()
+    return false
+end
+
+function Html5ExampleHudViewport:world()
+    return self._world
+end
+
+function Html5ExampleHudViewport:editor_camera()
+    return self._editor_camera
+end
+
+function Html5ExampleHudViewport:selected_units()
+    return {}
+end
+
+function Html5ExampleHudViewport:shading_environment()
+    return self._shading_environment
+end
+
 local run = function ()
-    return {type = "yes", n = 42}
+    local viewport_id = "67F13D18-D573-4CCE-BA47-EC571AAA4F54"
+    local viewport = Editor:viewport(viewport_id)
+    if viewport then
+        Editor:destroy_viewport(viewport_id)
+    end
+
+    viewport = Editor:create_viewport(viewport_id, "Html5ExampleHudViewport", nil, {
+        visible = true,
+        width = 1280,
+        height = 720,
+        title = "HTML5 HUD"
+    })
+
+    Window.set_show_cursor(viewport._window, true, false)
+    Window.set_clip_cursor(viewport._window, false)
+
+    local world = viewport._behavior._world
+    local gui = viewport._behavior._gui
+
+    local web_page_url = "http://www.google.com"
+    local web_view_material = Gui.material(gui, web_view_material_resource_name)
+    viewport._behavior._web_view = WebView.create(web_page_url, viewport._window, web_view_material)
+
+    return "Loaded web view "..web_page_url
+end
+
+-- Override editor viewport creator to fill missing window parametrization
+function Editor:create_viewport(id, behavior_class, parent_handle, options)
+	local constructor = _G[behavior_class]
+	assert(constructor ~= nil, "Tried creating viewport, but viewport behavior class could not be found.")
+
+	-- Create the viewport default window.
+	local window = nil
+	if Window then
+		if parent_handle then
+			window = Window.open{
+				parent = parent_handle,
+				explicit_resize = true,
+				pass_key_events_to_parent = true,
+				layered = true,
+				title = behavior_class,
+				visible = false
+			}
+		elseif options then
+			window = Window.open(options)
+		else
+			window = Window.open{ visible = false, explicit_resize = true, title = behavior_class }
+		end
+	end
+
+	assert(self._viewports[id] == nil, "Trying to create already existing viewport.")
+	local behavior = constructor(id, self, window)
+	local viewport = EditorViewport(id, behavior, window)
+	self._viewports[id] = viewport
+
+	if Window then
+		Application.console_send{ type = "viewport_handle", id = id, handle = Window.id(window) }
+	end
+
+	return viewport
 end
 
 return run

--- a/plugin/html5_examples/html5_hud.lua
+++ b/plugin/html5_examples/html5_hud.lua
@@ -1,0 +1,6 @@
+
+local run = function ()
+    return {type = "yes", n = 42}
+end
+
+return run

--- a/plugin/html5_examples/html5_hud.lua
+++ b/plugin/html5_examples/html5_hud.lua
@@ -4,6 +4,7 @@ local Application = stingray.Application;
 local World = stingray.World;
 local WebView = stingray.WebView;
 
+local web_page_url = "http://www.google.com"
 local web_view_material_resource_name = "html5_resources/web_view_2d"
 
 Html5ExampleHudViewport = class(Html5ExampleHudViewport)
@@ -13,110 +14,60 @@ function Html5ExampleHudViewport:init(id, editor, window)
     self._editor = editor
     self._window = window
 
-    self:init_world()
-    self:init_camera()
+    self._world = Application.new_world(stingray.Application.DISABLE_APEX_CLOTH)
+    self._viewport = Application.create_viewport(self._world, "default")
+    self._gui = World.create_screen_gui(self._world, "immediate")
+    self._light = self._editor:create_preview_light(self._world)
+    self._shading_environment = World.create_shading_environment(self._world)
+    self._editor_camera = EditorCamera.create_viewport_editor_camera(self._id, self._world, {"QuakeStyleMouseLook", "MayaStylePan"})
+    self._camera = self._editor_camera._camera
 end
 
 function Html5ExampleHudViewport:shutdown()
-
-    if self._web_view then
-        WebView.destroy(self._web_view)
-    end
-
+    WebView.destroy(self._web_view)
     World.destroy_unit(self._world, self._light)
     Application.destroy_viewport(self._world, self._viewport)
     World.destroy_shading_environment(self._world, self._shading_environment)
     Application.release_world(self._world)
-
-    if Window and self._window then
-        Window.close(self._window)
-    end
+    Window.close(self._window)
 
     self._web_view = nil
     self._viewport = nil
     self._window = nil
 end
 
-function Html5ExampleHudViewport:init_world()
-    -- Deactivate Cloth => cloth meshes will fall back to standard skinning rendering,
-    -- which is enough and immediate, whereas Cloth needs at least one frame to render.
-    self._world = Application.new_world(stingray.Application.DISABLE_APEX_CLOTH)
-    self._viewport = Application.create_viewport(self._world, "default")
-    self._gui = World.create_screen_gui(self._world, "immediate")
-    self._material_name = "core/editor_slave/resources/gui/thumbnail"
-    self._material = Gui.material(self._gui, self._material_name)
-    self._checkerboard = "core/editor_slave/resources/gui/checkerboard"
-    self._checkerboard_hdr = "core/editor_slave/resources/gui/checkerboard_hdr"
-    self._light = self._editor:create_preview_light(self._world)
-
-    self._shading_environment = World.create_shading_environment(self._world)
-
-    Material.set_scalar(Gui.material(self._gui, self._checkerboard), "size", 32)
-    Material.set_scalar(Gui.material(self._gui, self._checkerboard_hdr), "size", 32)
-
-    World.set_flow_enabled(self._world, false)
-    World.set_editor_flow_enabled(self._world, false)
-end
-
-function Html5ExampleHudViewport:init_camera()
-    self._editor_camera = EditorCamera.create_viewport_editor_camera(self._id, self._world, {"QuakeStyleMouseLook", "MayaStylePan"})
-    self._camera = self._editor_camera._camera
-end
-
 function Html5ExampleHudViewport:update(editor_viewport, dt)
-    if self._web_view then
-        WebView.update(self._web_view, dt)
-    end
-
+    WebView.update(self._web_view, dt)
     World.update(self._world, dt)
 end
 
 function Html5ExampleHudViewport:render(editor_viewport, lines, lines_no_z)
-    if self._web_view then
-         local maxw, maxh = Gui.resolution(self._viewport, self._window)
-         --print("render wv", maxw, maxh)
-         WebView.render(self._web_view)
-         Gui.bitmap(self._gui, web_view_material_resource_name, Vector2(0, 0), Vector2(maxw, maxh))
-     end
+    -- Render HTML4 HUD
+    local maxw, maxh = Gui.resolution(self._viewport, self._window)
+    WebView.render(self._web_view)
+    Gui.bitmap(self._gui, web_view_material_resource_name, Vector2(0, 0), Vector2(maxw, maxh))
 
-     if self._window ~= nil then
-        Application.render_world(self._world, self._editor_camera:camera(), self._viewport, self._shading_environment, self._window)
-    else
-        Application.render_world(self._world, self._editor_camera:camera(), self._viewport, self._shading_environment)
-    end
+    -- Render viewport content
+    Application.render_world(self._world, self._editor_camera:camera(), self._viewport, self._shading_environment, self._window)
 end
 
-function Html5ExampleHudViewport:is_dirty()
-    return true
-end
-
-function Html5ExampleHudViewport:is_accepting_drag_and_drop()
-    return false
-end
-
-function Html5ExampleHudViewport:world()
-    return self._world
-end
-
-function Html5ExampleHudViewport:editor_camera()
-    return self._editor_camera
-end
-
-function Html5ExampleHudViewport:selected_units()
-    return {}
-end
-
-function Html5ExampleHudViewport:shading_environment()
-    return self._shading_environment
-end
+function Html5ExampleHudViewport:world() return self._world end
+function Html5ExampleHudViewport:editor_camera() return self._editor_camera end
+function Html5ExampleHudViewport:shading_environment() return self._shading_environment end
+function Html5ExampleHudViewport:is_dirty() return true end
+function Html5ExampleHudViewport:is_accepting_drag_and_drop() return false end
+function Html5ExampleHudViewport:selected_units() return {} end
 
 local run = function ()
     local viewport_id = "67F13D18-D573-4CCE-BA47-EC571AAA4F54"
+
+    -- Destroy preview viewport if any.
     local viewport = Editor:viewport(viewport_id)
     if viewport then
         Editor:destroy_viewport(viewport_id)
     end
 
+    -- Create new viewport to host the HTML5 example
     viewport = Editor:create_viewport(viewport_id, "Html5ExampleHudViewport", nil, {
         visible = true,
         width = 1280,
@@ -127,17 +78,15 @@ local run = function ()
     Window.set_show_cursor(viewport._window, true, false)
     Window.set_clip_cursor(viewport._window, false)
 
-    local world = viewport._behavior._world
-    local gui = viewport._behavior._gui
-
-    local web_page_url = "http://www.google.com"
-    local web_view_material = Gui.material(gui, web_view_material_resource_name)
+    -- Create the HTML5 web view that will be the window viewport head-up display.
+    local web_view_material = Gui.material(viewport._behavior._gui, web_view_material_resource_name)
     viewport._behavior._web_view = WebView.create(web_page_url, viewport._window, web_view_material)
 
     return "Loaded web view "..web_page_url
 end
 
 -- Override editor viewport creator to fill missing window parametrization
+-- TODO: Port this to core repo
 function Editor:create_viewport(id, behavior_class, parent_handle, options)
 	local constructor = _G[behavior_class]
 	assert(constructor ~= nil, "Tried creating viewport, but viewport behavior class could not be found.")


### PR DESCRIPTION
###### Description:
Illustrate how to add a HUD to an engine window viewport.

When the HTML5 plugin is loaded you'll have a new menu item to show the HUD example:

![image](https://cloud.githubusercontent.com/assets/4054655/25204470/9f1e1738-252b-11e7-84b7-eaae9492f11a.png)

Once triggered you'll see an engine window display full screen a web page:

![image](https://cloud.githubusercontent.com/assets/4054655/25204503/bc7d9880-252b-11e7-97e9-da69959d3142.png)

All the example code is driven by the following lua script: https://github.com/jschmidt42/stingray-html5/blob/ef1500b53e7f13123978d3fe86bddef7a7ed571b/plugin/html5_examples/html5_hud.lua

Here we open the engine window in the context of the editor but the same can be applied in your application/project using or not AppKit.

You can find the `stingray.WebView.*` available APIs here: https://github.com/jschmidt42/stingray-html5/blob/master/engine/html5_api_lua.cpp#L108
